### PR TITLE
fix: auto merge workflow

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -12,6 +12,7 @@ on:
 permissions:
   pull-requests: write
   contents: write
+  issues: write
 
 jobs:
   auto-merge-and-update:
@@ -20,6 +21,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Process PR, Approve and Merge


### PR DESCRIPTION
Hi @terry07! Thanks for the contribution.
      
 I noticed the automated merge failed with a `Resource not accessible` error. This happens because our GitHub Actions currently lack the necessary permissions to process PRs from forks. 
      
I am updating the workflow settings now to fix this. Your PR will be merged as soon as the fix is in place!
