### PR TITLE
feat: release and uv

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -16,17 +16,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
 
-      - name: Install dependencies
-        run: pip install pyyaml jinja2
+      - name: Install Python and dependencies
+        run: uv sync --frozen
 
       - name: Run Scripts
         id: run_scripts
         continue-on-error: true
         run: |
-          python -m scripts.generate_readme
-          python -m scripts.generate_index
+          uv run python -m scripts.generate_readme
+          uv run python -m scripts.generate_index

--- a/.github/workflows/release-on-main.yaml
+++ b/.github/workflows/release-on-main.yaml
@@ -1,0 +1,101 @@
+name: Release on main
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-main
+  cancel-in-progress: false
+
+jobs:
+  release:
+    # Skip automated doc-sync commits (avoid a release on every bot push).
+    if: >
+      ${{ !contains(github.event.head_commit.message, '[skip ci]') &&
+          !contains(github.event.head_commit.message, '[no release]') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install git-cliff
+        env:
+          GIT_CLIFF_VERSION: "2.7.0"
+        run: |
+          set -euo pipefail
+          curl -sL "https://github.com/orhun/git-cliff/releases/download/v${GIT_CLIFF_VERSION}/git-cliff-${GIT_CLIFF_VERSION}-x86_64-unknown-linux-gnu.tar.gz" | tar xz
+          sudo install -m755 "git-cliff-${GIT_CLIFF_VERSION}/git-cliff" /usr/local/bin/git-cliff
+          git-cliff --version
+
+      - name: Build release notes
+        env:
+          REPO: ${{ github.repository }}
+          SITE: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/
+        run: |
+          set -euo pipefail
+          PREV="$(git describe --tags --match 'v*' --abbrev=0 2>/dev/null || true)"
+
+          {
+            echo "## Live directory"
+            echo ""
+            echo "**[Browse the curated list](${SITE})**"
+            echo ""
+            echo "---"
+            echo ""
+          } > release_notes.md
+
+          if [ -n "${PREV}" ]; then
+            echo "### Highlights (git-cliff)" >> release_notes.md
+            echo "" >> release_notes.md
+            git-cliff "${PREV}..HEAD" --strip header --config cliff.toml >> release_notes.md || true
+            echo "" >> release_notes.md
+          else
+            echo "### Highlights (git-cliff)" >> release_notes.md
+            echo "" >> release_notes.md
+            git-cliff --strip header --config cliff.toml >> release_notes.md || true
+            echo "" >> release_notes.md
+          fi
+
+          echo "---" >> release_notes.md
+          echo "" >> release_notes.md
+          echo "### All commits in this release" >> release_notes.md
+          echo "" >> release_notes.md
+          echo "Every commit included in this tag (newest first):" >> release_notes.md
+          echo "" >> release_notes.md
+
+          if [ -n "${PREV}" ]; then
+            git log "${PREV}..HEAD" --pretty=format:'- %s ([`%h`](https://github.com/'"${REPO}"'/commit/%H))' >> release_notes.md
+          else
+            git log --pretty=format:'- %s ([`%h`](https://github.com/'"${REPO}"'/commit/%H))' >> release_notes.md
+          fi
+          echo "" >> release_notes.md
+
+      - name: Random release title
+        id: title
+        run: |
+          A=(Swift Calm Bold Bright Cedar Clever Coral Cosmic Crystal Curious Daring Ember Golden Ivory Jade Lunar Marble Noble Olive Pearl Quiet Rapid Ruby Silent Silver Solar Steady Swift Velvet Violet)
+          N=(Badger Beaver Brook Canyon Comet Delta Dolphin Eagle Falcon Harbor Heron Island Lighthouse Maple Meadow Otter Pine River Sage Summit Valley Willow)
+          i=$((RANDOM % ${#A[@]}))
+          j=$((RANDOM % ${#N[@]}))
+          echo "name=${A[i]} ${N[j]}" >> "$GITHUB_OUTPUT"
+
+      - name: Next version tag
+        id: ver
+        run: |
+          TAG="v$(date -u +%Y.%m.%d).${GITHUB_RUN_NUMBER}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.ver.outputs.tag }}" \
+            --title "${{ steps.title.outputs.name }}" \
+            --notes-file release_notes.md

--- a/.github/workflows/sync-on-main-merge.yaml
+++ b/.github/workflows/sync-on-main-merge.yaml
@@ -16,18 +16,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
 
-      - name: Install dependencies
-        run: pip install pyyaml jinja2
+      - name: Install Python and dependencies
+        run: uv sync --frozen
 
       - name: Sync Content
         run: |
-          python -m scripts.generate_readme
-          python -m scripts.generate_index
+          uv run python -m scripts.generate_readme
+          uv run python -m scripts.generate_index
 
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,19 @@
+# https://git-cliff.org/docs/configuration
+# Release notes are generated for GitHub Releases via git-cliff in CI.
+
+[changelog]
+header = "## What's changed\n\n"
+trim = true
+# render = ...
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+
+commit_parsers = [
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^doc", group = "Documentation" },
+    { message = "^chore", group = "Chores" },
+    { message = ".*", group = "Other" },
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "awesome-greek-tech-jobs"
+version = "0.0.0"
+description = "Generator tooling for the Awesome Greek Tech Jobs directory"
+readme = "readme.md"
+requires-python = ">=3.10"
+dependencies = [
+    "jinja2>=3.1",
+    "pyyaml>=6.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["scripts"]

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Generator scripts (readme, index HTML, data normalization)."""


### PR DESCRIPTION
## Summary
- **Local dev:** Add `pyproject.toml`, `scripts` package, and document **uv** (`uv sync`, `uv run`) for generator deps.
- **CI:** Use **uv** in PR validation and main-branch sync workflows; keep `uv.lock` for reproducible installs.
- **Releases:** Add **git-cliff** + workflow on `main` (skips `[skip ci]` / `[no release]`) with random release titles; notes include **live site link** + git-cliff highlights + **full commit list** with GitHub links.
- **Changelog config:** Add `cliff.toml` for release note grouping.

## How to verify
- `uv sync` then `uv run python -m scripts.generate_readme` / `generate_index` succeed locally.
- Merge to `main` (non–`[skip ci]`): release is created with site URL and complete commit list.