### PR TITLE
feat(ci): harden workable sync, switch to weekly updates

### DIFF
--- a/.github/workflows/release-on-main.yaml
+++ b/.github/workflows/release-on-main.yaml
@@ -14,9 +14,10 @@ concurrency:
 
 jobs:
   release:
-    # Skip automated doc-sync commits (avoid a release on every bot push).
+    # Release only when a main-branch commit message explicitly includes "release".
     if: >
-      ${{ !contains(github.event.head_commit.message, '[skip ci]') &&
+      ${{ contains(github.event.head_commit.message, 'release') &&
+          !contains(github.event.head_commit.message, '[skip ci]') &&
           !contains(github.event.head_commit.message, '[no release]') }}
     runs-on: ubuntu-latest
     steps:
@@ -34,15 +35,25 @@ jobs:
           sudo install -m755 "git-cliff-${GIT_CLIFF_VERSION}/git-cliff" /usr/local/bin/git-cliff
           git-cliff --version
 
-      - name: Random release title & version tag
+      - name: Mountain release title & semver tag
         id: meta
         run: |
-          A=(Swift Calm Bold Bright Cedar Clever Coral Cosmic Crystal Curious Daring Ember Golden Ivory Jade Lunar Marble Noble Olive Pearl Quiet Rapid Ruby Silent Silver Solar Steady Swift Velvet Violet)
-          N=(Badger Beaver Brook Canyon Comet Delta Dolphin Eagle Falcon Harbor Heron Island Lighthouse Maple Meadow Otter Pine River Sage Summit Valley Willow)
-          i=$((RANDOM % ${#A[@]}))
-          j=$((RANDOM % ${#N[@]}))
-          TAG="v$(date -u +%Y.%m.%d).${GITHUB_RUN_NUMBER}"
-          echo "name=${A[i]} ${N[j]}" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          NEXT="$(git-cliff --bumped-version --config cliff.toml)"
+          TAG="${NEXT#v}"
+          TAG="v${TAG}"
+
+          PEAKS=(
+            "Everest" "K2" "Kangchenjunga" "Lhotse" "Makalu" "Cho Oyu"
+            "Dhaulagiri" "Manaslu" "Nanga Parbat" "Annapurna" "Denali"
+            "Aconcagua" "Kilimanjaro" "Elbrus" "Vinson" "Puncak Jaya"
+            "Mont Blanc" "Matterhorn" "Olympus" "Triglav"
+          )
+          HASH="$(printf '%s' "${GITHUB_SHA}${TAG}" | cksum | cut -d' ' -f1)"
+          IDX=$((HASH % ${#PEAKS[@]}))
+          NAME="${PEAKS[$IDX]} Peak"
+
+          echo "name=${NAME}" >> "$GITHUB_OUTPUT"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Build release notes
@@ -62,5 +73,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release create "${{ steps.meta.outputs.tag }}" \
-            --title "${{ steps.meta.outputs.name }} · ${{ steps.meta.outputs.tag }}" \
+            --title "${{ steps.meta.outputs.name }} ${{ steps.meta.outputs.tag }}" \
             --notes-file release_notes.md

--- a/.github/workflows/sync-on-main-merge.yaml
+++ b/.github/workflows/sync-on-main-merge.yaml
@@ -5,8 +5,8 @@ on:
     branches:
       - main
   schedule:
-    # Daily 05:00 UTC — refresh Workable Greece incountry counts + regenerate index.html
-    - cron: "0 5 * * *"
+    # Weekly Monday 05:00 UTC — refresh Workable Greece counts + regenerate index.html
+    - cron: "0 5 * * 1"
   workflow_dispatch:
 
 permissions:
@@ -63,7 +63,7 @@ jobs:
             if git diff --staged --quiet; then
               echo "No changes to commit."
             else
-              git commit -m "chore: refresh Workable job counts (scheduled 05:00 UTC) [skip ci]"
+              git commit -m "chore: refresh Workable job counts (weekly schedule) [skip ci]"
               git push origin main
             fi
           fi

--- a/readme.yaml
+++ b/readme.yaml
@@ -12,7 +12,7 @@ disclaimer: >
   This project is for **community and educational purposes only**.
   All data is aggregated from publicly available sources (company
   websites, LinkedIn, Workable's public API).  Job counts shown are
-  **cached snapshots** generated once daily and **do not represent
+  **cached snapshots** generated weekly and **do not represent
   a real-time official database**.
 
 
@@ -50,5 +50,5 @@ footer:
       content: "Focus on System Design for Senior roles and LeetCode (Medium) for mid-level."
     - title: "Job Counts"
       content: >
-        Workable counts are fetched daily via CI from the public API and
+        Workable counts are fetched weekly via CI from the public API and
         may be inaccurate due to timing, geography filters, or API behavior.

--- a/scripts/fetch_workable_counts.py
+++ b/scripts/fetch_workable_counts.py
@@ -1,15 +1,18 @@
-"""Fetch open-job counts from Workable using /count endpoints only.
+"""Fetch open-job counts from Workable public endpoints.
 
-Tries a small set of ``/count`` URL variants per slug and uses the first
-usable response. If all variants fail, stores ``0`` for that slug so the whole
-list is always completed in one run.
+Primary source is ``/count`` (fast). If ``/count`` appears geo-biased (for
+example ``total > 0`` but ``incountry = 0``) or otherwise unusable, this
+script falls back to Workable's public v3 jobs endpoint filtered by
+``location.countryCode = GR``.
 """
 
 from __future__ import annotations
 
 import sys
 import time
+import os
 from pathlib import Path
+from urllib.robotparser import RobotFileParser
 
 import requests
 import yaml
@@ -32,12 +35,25 @@ _COUNT_URL_CANDIDATES = (
     "https://apply.workable.com/api/v1/accounts/{slug}/jobs/count?country=Greece",
     "https://apply.workable.com/api/v1/accounts/{slug}/jobs/count?country=GR",
 )
+_V3_JOBS_URL = "https://apply.workable.com/api/v3/accounts/{slug}/jobs"
+_V3_GR_LOCATION_FILTER = {"location": [{"countryCode": "GR"}]}
+_ROBOTS_TXT_URL = "https://www.workable.com/robots.txt"
+_ROBOTS_ENDPOINT_PROBES = (
+    "https://apply.workable.com/api/v1/accounts/example/jobs/count",
+    "https://apply.workable.com/api/v3/accounts/example/jobs",
+)
 
 _USER_AGENT = (
     "awesome-greek-tech-jobs/1.0 "
     "(+https://github.com/leftkats/awesome-greek-tech-jobs; "
     "python-requests; Greece job board snapshot)"
 )
+_VERBOSE = os.getenv("WORKABLE_VERBOSE", "").strip().lower() in {
+    "1",
+    "true",
+    "yes",
+    "on",
+}
 
 
 def _build_session() -> requests.Session:
@@ -65,70 +81,164 @@ def _build_session() -> requests.Session:
     return session
 
 
+def _debug(msg: str) -> None:
+    if _VERBOSE:
+        print(msg, file=sys.stderr)
+
+
+def _ensure_robots_allows_fetch(session: requests.Session) -> None:
+    """Fail fast if workable.com robots.txt disallows endpoint probes."""
+    try:
+        resp = session.get(_ROBOTS_TXT_URL, timeout=TIMEOUT_SEC)
+    except requests.RequestException as e:
+        raise RuntimeError(f"robots.txt fetch failed: {e}") from e
+
+    if resp.status_code != 200:
+        raise RuntimeError(
+            f"robots.txt fetch returned HTTP {resp.status_code}"
+        )
+
+    rp = RobotFileParser()
+    rp.parse(resp.text.splitlines())
+    for endpoint_url in _ROBOTS_ENDPOINT_PROBES:
+        if not rp.can_fetch(_USER_AGENT, endpoint_url):
+            raise RuntimeError(
+                "robots.txt disallows endpoint probe: "
+                f"{endpoint_url}"
+            )
+    print(f"robots.txt check passed ({_ROBOTS_TXT_URL})")
+
+
 def _fetch_count_from_count_endpoints(
     session: requests.Session, slug: str, idx: int = 0, total: int = 0
-) -> int | None:
+) -> tuple[int | None, int | None, bool]:
     """Try /count variants first; skip geo-mismatched results and continue."""
-    prefix = f"[{idx}/{total}] {slug}"
     headers = {
         "Origin": "https://apply.workable.com",
         "Referer": f"https://apply.workable.com/{slug}/",
     }
+    last_status: int | None = None
+    saw_geo_mismatch = False
 
     for candidate in _COUNT_URL_CANDIDATES:
         url = candidate.format(slug=slug)
         try:
             resp = session.get(url, headers=headers, timeout=TIMEOUT_SEC)
         except requests.RequestException as e:
-            print(f"{prefix}: /count FAILED ({url}) → {e}", file=sys.stderr)
+            _debug(f"/count request failed for {slug} ({url}) -> {e}")
             continue
 
+        last_status = resp.status_code
         if resp.status_code != 200:
-            print(
-                f"{prefix}: /count HTTP {resp.status_code} ({url}) → {resp.text[:200]}".strip(),
-                file=sys.stderr,
+            _debug(
+                f"/count HTTP {resp.status_code} for {slug} ({url}) -> "
+                f"{resp.text[:200]}".strip()
             )
             continue
 
         try:
             data = resp.json()
         except ValueError:
-            print(f"{prefix}: /count invalid JSON ({url})", file=sys.stderr)
+            _debug(f"/count invalid JSON for {slug} ({url})")
             continue
 
         raw_total = data.get("total")
         raw_incountry = data.get("incountry")
         if not isinstance(raw_total, int) or not isinstance(raw_incountry, int):
-            print(f"{prefix}: /count missing keys ({url})", file=sys.stderr)
+            _debug(f"/count missing keys for {slug} ({url})")
             continue
 
         # If there are jobs but requester-geo "incountry" is 0, this endpoint is
-        # likely not reflecting Greece. Continue to the next /count candidate.
+        # likely not reflecting Greece for CI; mark and continue.
         if raw_total > 0 and raw_incountry == 0:
-            print(
-                f"{prefix}: /count geo mismatch ({url}) total={raw_total} incountry=0; trying next"
+            saw_geo_mismatch = True
+            _debug(
+                f"/count geo mismatch for {slug} ({url}) total={raw_total} "
+                "incountry=0"
             )
             continue
 
-        print(f"{prefix}: /count hit ({url}) → {raw_incountry}/{raw_total}")
-        return raw_incountry
+        return raw_incountry, resp.status_code, False
 
-    return None
+    return None, last_status, saw_geo_mismatch
+
+
+def _fetch_count_from_v3_gr_location(
+    session: requests.Session, slug: str
+) -> tuple[int | None, int | None]:
+    """Fallback using public v3 endpoint with explicit Greece location filter."""
+    url = _V3_JOBS_URL.format(slug=slug)
+    headers = {
+        "Origin": "https://apply.workable.com",
+        "Referer": f"https://apply.workable.com/{slug}/",
+        "Content-Type": "application/json",
+    }
+    try:
+        resp = session.post(
+            url,
+            headers=headers,
+            json=_V3_GR_LOCATION_FILTER,
+            timeout=TIMEOUT_SEC,
+        )
+    except requests.RequestException as e:
+        _debug(f"/v3 request failed for {slug} ({url}) -> {e}")
+        return None, None
+
+    if resp.status_code != 200:
+        _debug(
+            f"/v3 HTTP {resp.status_code} for {slug} ({url}) -> "
+            f"{resp.text[:200]}".strip()
+        )
+        return None, resp.status_code
+
+    try:
+        data = resp.json()
+    except ValueError:
+        _debug(f"/v3 invalid JSON for {slug} ({url})")
+        return None, resp.status_code
+
+    raw_total = data.get("total")
+    if not isinstance(raw_total, int):
+        _debug(f"/v3 missing total for {slug} ({url})")
+        return None, resp.status_code
+    return raw_total, resp.status_code
 
 
 def fetch_count(
     session: requests.Session, slug: str, idx: int = 0, total: int = 0
 ) -> int:
-    """Fetch count from /count endpoints only; return 0 on failure."""
+    """Fetch Greece count, using /count first then v3 GR fallback."""
     prefix = f"[{idx}/{total}] {slug}"
-    count_value = _fetch_count_from_count_endpoints(session, slug, idx=idx, total=total)
+    count_value, count_status, saw_geo_mismatch = _fetch_count_from_count_endpoints(
+        session, slug, idx=idx, total=total
+    )
     if isinstance(count_value, int):
+        print(f"{prefix}: /count HTTP {count_status or 200} -> {count_value}")
         return count_value
-    print(f"{prefix}: all /count endpoints failed; using 0", file=sys.stderr)
+
+    v3_value, v3_status = _fetch_count_from_v3_gr_location(session, slug)
+    if isinstance(v3_value, int):
+        source = "/v3(location=GR)"
+        if saw_geo_mismatch:
+            source = "/v3(location=GR) fallback-from-geo-mismatch"
+        print(f"{prefix}: {source} HTTP {v3_status or 200} -> {v3_value}")
+        return v3_value
+
+    print(
+        f"{prefix}: /count HTTP {count_status or 'ERR'}, "
+        f"/v3 HTTP {v3_status or 'ERR'} -> 0"
+    )
     return 0
 
 
 def main() -> int:
+    session = _build_session()
+    try:
+        _ensure_robots_allows_fetch(session)
+    except RuntimeError as e:
+        print(f"Workable fetch aborted: {e}", file=sys.stderr)
+        return 2
+
     with YAML_PATH.open(encoding="utf-8") as f:
         companies = yaml.safe_load(f)
 
@@ -140,7 +250,6 @@ def main() -> int:
             seen.add(slug)
             slugs.append(slug)
 
-    session = _build_session()
     accounts: dict[str, int] = {}
 
     print(f"Fetching {len(slugs)} Workable accounts…")
@@ -152,7 +261,7 @@ def main() -> int:
     total_open = sum(accounts.values())
     out = {
         "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-        "metric": "incountry_greece",
+        "metric": "greece_country_code_gr",
         "accounts": accounts,
         "total_open": total_open,
     }
@@ -160,8 +269,8 @@ def main() -> int:
     OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
     with OUTPUT_PATH.open("w", encoding="utf-8") as f:
         f.write(
-            "# Workable Greece incountry counts from /count endpoints (generated by "
-            "scripts/fetch_workable_counts)\n"
+            "# Workable Greece counts from public /count + /v3 jobs endpoints "
+            "(generated by scripts/fetch_workable_counts)\n"
         )
         yaml.dump(
             out,

--- a/scripts/generate_index.py
+++ b/scripts/generate_index.py
@@ -16,7 +16,7 @@ Run
 * ``uv run python -m scripts.generate_index --fetch-workable`` — fetch then render.
 
 CI: ``.github/workflows/sync-on-main-merge.yaml`` runs fetch + generate on push to
-``main`` and daily at 05:00 UTC; commits ``data/workable_counts.yaml`` and
+``main`` and weekly (Monday 05:00 UTC); commits ``data/workable_counts.yaml`` and
 ``index.html``. Paths align with ``scripts.fetch_workable_counts``.
 """
 

--- a/scripts/generate_readme.py
+++ b/scripts/generate_readme.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections import Counter
+from pathlib import Path
 
 import yaml
 
@@ -16,6 +17,16 @@ def generate() -> None:
 
     with open("data/queries.yaml", "r", encoding="utf-8") as f:
         queries_data = yaml.safe_load(f)
+
+    workable_counts_path = Path("data/workable_counts.yaml")
+    open_roles = 0
+    if workable_counts_path.exists():
+        with workable_counts_path.open("r", encoding="utf-8") as f:
+            workable_data = yaml.safe_load(f) or {}
+        if isinstance(workable_data, dict):
+            maybe_total = workable_data.get("total_open")
+            if isinstance(maybe_total, int):
+                open_roles = maybe_total
 
     all_companies = sorted(
         companies_data, key=lambda x: x["name"].lower()
@@ -84,7 +95,10 @@ def generate() -> None:
         "-green?style=for-the-badge) "
         "![Hybrid]"
         f"(https://img.shields.io/badge/Hybrid-{hybrid}"
-        "-yellow?style=for-the-badge)"
+        "-yellow?style=for-the-badge) "
+        "![Open Roles]"
+        f"(https://img.shields.io/badge/Open%20Roles-{open_roles}"
+        "-orange?style=for-the-badge)"
     )
     lines.append(badge)
     lines.append("")
@@ -140,6 +154,8 @@ def generate() -> None:
         lines.append("## Tips & Notes\n")
         for n in notes:
             title = n["title"]
+            if title.strip().lower() == "job counts":
+                title = "Job Counts (Experimental)"
             body = n["content"].strip()
             lines.append(f"- **{title}:** {body}")
         lines.append("")


### PR DESCRIPTION
## What changed
- Added a robots.txt pre-check in scripts/fetch_workable_counts.py to validate Workable access before fetching.
- Improved Workable counting logic with public endpoint fallback and cleaner per-account response logging.
- Switched Workable sync schedule from daily to weekly (Monday 05:00 UTC).
- Updated docs and generated outputs to reflect weekly snapshot cadence.
- Included engineering-hubs.md in auto-sync commit flow on main.
